### PR TITLE
add 'visible' for a collapsed list

### DIFF
--- a/lib/navi-tree.js
+++ b/lib/navi-tree.js
@@ -310,6 +310,11 @@ class TreeView {
     let stackClass   = this.item.stackCount   >0 ? ' stack'   : ''
     let currentClass = this.item.currentCount >0 ? ' current' : ''
     let visibleClass = this.item.visibility   >0 ? ' visible' : ''
+    if (!this.item.visibility && this.item.children.length) {
+      if (!this.showChildren && this.checkChildrenVisibility(this.item)) {
+        visibleClass = ' visible'
+      }
+    }
     let naviClass    = this.item.classList.length ? ' '+this.item.classList.join(' ') : ''
     let text = this.item.display ? this.item.display : this.item.text
     return <div class={"navigation-tree"+stackClass}>
@@ -319,6 +324,10 @@ class TreeView {
       </div>
       {naviList}
     </div>
+  }
+
+  checkChildrenVisibility(item) {
+    return item.visibility || !!item.children.filter(child => this.checkChildrenVisibility(child)).length
   }
 
   scrollToLine(e) {


### PR DESCRIPTION
Add 'visible' className for collapsed lists with visible children not headers